### PR TITLE
Use gleam_erlang 1.2.0

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -11,9 +11,8 @@ links = [
 repository = { type = "github", user = "RudolfVonKrugstein", repo = "gleam_processgroups" }
 
 [dependencies]
-gleam_stdlib = ">= 0.54.0 and < 1.0.0"
-gleam_erlang = ">= 0.34.0 and < 1.0.0"
+gleam_stdlib = ">= 0.60.0 and < 1.0.0"
+gleam_erlang = ">= 1.2.0 and < 2.0.0"
 
 [dev-dependencies]
-gleam_otp = ">= 0.16.1 and < 1.0.0"
 gleeunit = ">= 1.3.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
-  { name = "gleam_otp", version = "0.16.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "50DA1539FC8E8FA09924EB36A67A2BBB0AD6B27BCDED5A7EF627057CF69D035E" },
-  { name = "gleam_stdlib", version = "0.54.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "723BA61A2BAE8D67406E59DD88CEA1B3C3F266FC8D70F64BE9FEC81B4505B927" },
-  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
+  { name = "gleam_erlang", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "F91CE62A2D011FA13341F3723DB7DB118541AAA5FE7311BD2716D018F01EF9E3" },
+  { name = "gleam_stdlib", version = "0.61.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3DC407D6EDA98FCE089150C11F3AD892B6F4C3CA77C87A97BAE8D5AB5E41F331" },
+  { name = "gleeunit", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "63022D81C12C17B7F1A60E029964E830A4CBD846BBC6740004FC1F1031AE0326" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.34.0 and < 1.0.0" }
-gleam_otp = { version = ">= 0.16.1 and < 1.0.0" }
-gleam_stdlib = { version = ">= 0.54.0 and < 1.0.0" }
+gleam_erlang = { version = ">= 1.2.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.60.0 and < 1.0.0" }
 gleeunit = { version = ">= 1.3.0 and < 2.0.0" }

--- a/src/processgroups_ffi.erl
+++ b/src/processgroups_ffi.erl
@@ -1,0 +1,5 @@
+-module(processgroups_ffi).
+-export([pid_decoder/1]).
+
+pid_decoder(Pid) when is_pid(Pid) -> {ok, Pid};
+pid_decoder(_Pid) -> {error, nil}.


### PR DESCRIPTION
The `gleam_erlang` dependency was bumped to 1.2.0. Tests pass, but you may want to carefully review the changes.

The most involved changes were in the `selecting_process_group_monitor` function, to deal with the new decoding API. I assert that the tuple fields exist as they should be guaranteed by the length argument to `select_record` AFAIK. I also wrote a little FFI helper for decoding PIDs as the decoder was removed from `gleam_erlang`.